### PR TITLE
Add eslint-plugin-cypress to prevent eslint errors on cypress tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['airbnb', 'prettier', "plugin:react/recommended"],
+  extends: ['airbnb', 'prettier', "plugin:react/recommended", "plugin:cypress/recommended"],
   plugins: ['prettier'],
   rules: {
     'arrow-body-style': ['error', 'as-needed'],

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -19,4 +19,4 @@
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
-}
+};

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -14,7 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+import "./commands";
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eslint": "^6.8.0",
     "eslint-config-airbnb": "^18.1.0",
     "eslint-config-prettier": "^6.10.0",
+    "eslint-plugin-cypress": "^2.11.3",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.1.2",


### PR DESCRIPTION
**How to test:**
- open any cypress tests in your favorite editor (with eslint on);
- verify that no eslint errors related to cypress appear.

**Description of your solution:**
I added an eslint plugin that injects cypress variables and types into the eslint checks, making sure that no errors related to cypress appear.
